### PR TITLE
use local date instead of UTC

### DIFF
--- a/packages/desktop/src/utils/ethereum.js
+++ b/packages/desktop/src/utils/ethereum.js
@@ -32,19 +32,19 @@ export const getUserAccounts = async (provider) => {
 };
 
 export const signAddress = async (provider, address) => {
-  const signedAt = new Date().toISOString();
+  const signedAt = new Date();
   const nonce = crypto.getRandomValues(new Uint32Array(1))[0];
   const message = `NewShades wants you to sign in with your web3 account
 ${address}
 
 URI: ${location.origin}
 Nonce: ${nonce}
-Issued At: ${signedAt}`;
+Issued At: ${signedAt.toDateString()}, ${signedAt.toLocaleTimeString()}`;
 
   const signature = await provider.request({
     method: "personal_sign",
     params: [address, message],
   });
 
-  return [signature, message, signedAt, nonce];
+  return [signature, message, signedAt.toISOString(), nonce];
 };


### PR DESCRIPTION
Show the "Issued At" date in the local timezone, rather than UTC. Better UX for end-user, not have to think about timezones.

Before:
```
Issued At: 2022-01-28T14:33:23.354Z
```

After:
```
Issued At: Fri Jan 28 2022, 15:33:23
```