### PR TITLE
allow diff channel names per clients connected

### DIFF
--- a/packages/common/src/server-connection.js
+++ b/packages/common/src/server-connection.js
@@ -54,7 +54,9 @@ export const Provider = ({ Pusher, pusherKey, debug = false, children }) => {
       },
     });
 
-    const channel = pusher.subscribe(`private-${user.id}`);
+    const nonce = crypto.getRandomValues(new Uint32Array(1))[0];
+    const channelName = `private-${user.id}-${nonce}`;
+    const channel = pusher.subscribe(channelName);
     channelRef.current = channel;
 
     const serverEvents = Object.keys(serverEventMap);


### PR DESCRIPTION
As it stands, when a user opens the app on multiple clients (desktop, phone, multiple browsers), the channel name created by the apps is reused for each client.

This changes that to create unique channels per client instead.