### PR TITLE
Fixes search results without displayName where query still has match (for example empty word when using 'name.tld' or 'record.name.tld')

### DIFF
--- a/packages/common/src/utils/user.js
+++ b/packages/common/src/utils/user.js
@@ -39,7 +39,7 @@ export const search = (users, rawQuery) => {
       },
       (u) => {
         if (!matchString(u.displayName ?? "", query)) return Infinity;
-        return u.displayName.length;
+        return u.displayName?.length;
       },
       (u) => u.displayName?.toLowerCase()
     ),


### PR DESCRIPTION
Attempt at fixing searching after for example `werme.eth` or `0.coa.eth` (or just `.` alone) which without this change would raise a "TypeError: Cannot read properties of undefined (reading 'length')" error.

<img width="1540" alt="image" src="https://user-images.githubusercontent.com/89139/235925242-9907525a-f7ca-499c-890c-31c6e784ab0c.png">
