### PR TITLE
Fix dummy id generator

### DIFF
--- a/packages/common/src/utils/misc.js
+++ b/packages/common/src/utils/misc.js
@@ -2,8 +2,8 @@ import { sortBy } from "./array.js";
 
 let prevDummyId = 0;
 export const generateDummyId = () => {
-  const id = prevDummyId++;
-  prevDummyId = id;
+  const id = prevDummyId;
+  prevDummyId += 1;
   return id;
 };
 

--- a/packages/common/src/utils/misc.test.js
+++ b/packages/common/src/utils/misc.test.js
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vitest";
+import { generateDummyId } from "./misc.js";
+
+describe("generateDummyId", () => {
+  test("increments the returned id each call", () => {
+    const first = generateDummyId();
+    const second = generateDummyId();
+    const third = generateDummyId();
+    expect([first, second, third]).toEqual([0, 1, 2]);
+  });
+});


### PR DESCRIPTION
## Summary
- fix `generateDummyId` increment logic
- add a unit test for the function

## Testing
- `pnpm --filter @shades/common exec vitest run`
- `pnpm --filter nouns-camp test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_6841f0256f2c8321aef8e2f8df83d4cd